### PR TITLE
feat: 模型输出结果操作按钮优化。

### DIFF
--- a/packages/b-component/src/chat/message-item/answer-item/components/answer-actions/AnswerActions.tsx
+++ b/packages/b-component/src/chat/message-item/answer-item/components/answer-actions/AnswerActions.tsx
@@ -1,7 +1,7 @@
+import { BorderOutlined, XFilled } from '@ant-design/icons';
 import { EModalAnswerStatus, TModelAnswerCell, useChatMsgCtx } from '@evo/data-store';
 import { Flex, Tooltip } from 'antd';
 
-import { BorderOutlined } from '@ant-design/icons';
 import React from 'react';
 import style from './Style.module.scss';
 import { useCellValueSelector } from '@evo/utils';
@@ -26,7 +26,7 @@ export const AnswerActions = React.memo<IAnswerActionsProps>((props) => {
     return (
       <Flex className={style.container}>
         <Tooltip title="停止内容生成">
-          <BorderOutlined className={style['stop-icon']} onClick={stopModel} />
+          <XFilled className={style['stop-icon']} onClick={stopModel} />
         </Tooltip>
       </Flex>
     );

--- a/packages/b-component/src/chat/message-item/answer-item/components/answer-actions/Style.module.scss
+++ b/packages/b-component/src/chat/message-item/answer-item/components/answer-actions/Style.module.scss
@@ -5,6 +5,7 @@
     cursor: pointer;
     font-size: 16px;
     position: relative;
+    color: red;
 
     &::after {
       content: '';

--- a/packages/b-component/src/chat/message-item/answer-item/components/answer-toolbar/AnswerToolbar.tsx
+++ b/packages/b-component/src/chat/message-item/answer-item/components/answer-toolbar/AnswerToolbar.tsx
@@ -1,16 +1,15 @@
 import { CopyOutlined, DeleteOutlined, SyncOutlined } from '@ant-design/icons';
 import {
   EModalAnswerStatus,
-  TModelAnswer,
   TModelAnswerCell,
   useChatMsgCtx,
   useChatWinCtx,
 } from '@evo/data-store';
-import { Flex, Tooltip } from 'antd';
-import React, { useDeferredValue, useMemo } from 'react';
-import { useCellValue, useCellValueSelector } from '@evo/utils';
+import { Flex, Popconfirm, Tooltip } from 'antd';
 
+import React from 'react';
 import style from './Style.module.scss';
+import { useCellValueSelector } from '@evo/utils';
 import { useMemoizedFn } from 'ahooks';
 
 export interface IAnswerToolbarProps {
@@ -52,7 +51,19 @@ export const AnswerToolbar = React.memo<IAnswerToolbarProps>((props) => {
           <CopyOutlined onClick={copyModelAnswer} />
         </Tooltip>
         <Tooltip title="删除">
-          <DeleteOutlined onClick={removeModel} />
+          <Popconfirm
+            title="请确认"
+            description="确定要删除该输出结果?"
+            onConfirm={removeModel}
+            okText="删除"
+            okType="danger"
+            okButtonProps={{
+              type: 'primary',
+            }}
+            cancelText="取消"
+          >
+            <DeleteOutlined />
+          </Popconfirm>
         </Tooltip>
       </Flex>
     );

--- a/packages/b-component/src/chat/message-item/message-toolbar/MessageToolbar.tsx
+++ b/packages/b-component/src/chat/message-item/message-toolbar/MessageToolbar.tsx
@@ -1,5 +1,5 @@
 import { CopyOutlined, DeleteOutlined, SendOutlined, SyncOutlined } from '@ant-design/icons';
-import { Dropdown, MenuProps } from 'antd';
+import { Dropdown, MenuProps, Popconfirm, Tooltip } from 'antd';
 import React, { useMemo } from 'react';
 import { useChatMsgCtx, useChatWinCtx } from '@evo/data-store';
 
@@ -70,12 +70,21 @@ export const MessageToolbar = React.memo<IMessageToolbarProps>((props) => {
         key: '3',
         className: style['action-item'],
         label: (
-          <>
+          <Popconfirm
+            title="请确认"
+            description="确定要删除该消息?"
+            onConfirm={removeMessage}
+            okText="删除"
+            okType="danger"
+            okButtonProps={{
+              type: 'primary',
+            }}
+            cancelText="取消"
+          >
             <DeleteOutlined className={style['action-icon']} />
             删除
-          </>
+          </Popconfirm>
         ),
-        onClick: removeMessage,
       },
       {
         key: '4',

--- a/packages/b-component/src/chat/message-item/message-toolbar/Style.module.scss
+++ b/packages/b-component/src/chat/message-item/message-toolbar/Style.module.scss
@@ -1,5 +1,7 @@
 .action-item {
+  min-width: 90px;
+
   .action-icon {
-    margin-right: 4px;
+    margin-right: 6px;
   }
 }


### PR DESCRIPTION
[feat: 删除消息和模型输出结果按钮增加二次确认]

[style: 停止模型输出按钮改为实心红色icon]